### PR TITLE
Silence `make check' warning

### DIFF
--- a/leftpad-test.c
+++ b/leftpad-test.c
@@ -4,7 +4,7 @@
 
 #include "leftpad.h"
 
-int do_test(char* a, char* b)
+static int do_test(char* a, char* b)
 {
     return 0 != strcmp(a, b);
 }


### PR DESCRIPTION
```
make check
/usr/bin/make  leftpad-test
  CC       leftpad-test.o
leftpad-test.c:7:5: warning: no previous prototype for function 'do_test' [-Wmissing-prototypes]
int do_test(char* a, char* b)
    ^
1 warning generated.
```